### PR TITLE
[feat] #6  일반 회원의 네이버 로그인 기능 구현

### DIFF
--- a/src/main/java/kyonggi/bookslyserver/domain/user/entity/User.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/entity/User.java
@@ -23,6 +23,7 @@ public class User extends BaseTimeEntity {
 
     @Column(name="social_id")
     private String socialId;
+    private String email;
 
     @Enumerated(value = EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(10) DEFAULT 'ROLE_USER'")

--- a/src/main/java/kyonggi/bookslyserver/domain/user/repository/UserRepository.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/repository/UserRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findBySocialId(String email);
+    Optional<User> findBySocialId(String socialId);
 
 }

--- a/src/main/java/kyonggi/bookslyserver/domain/user/service/UserService.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/service/UserService.java
@@ -24,28 +24,28 @@ public class UserService {
      * @return 유저 객체
      */
     public User getOrCreateUser(OAuth2UserInfo userInfo) {
+        String socialId = userInfo.getIdByProvider();
         String email = userInfo.getEmail();
         String nickname = userInfo.getNickname();
         String profileImgUrl = userInfo.getProfileImgUrl();
 
-        return userRepository.findBySocialId(email)
+        return userRepository.findBySocialId(socialId)
                 .map(user -> {
                     user.updateUserInfo(nickname, profileImgUrl);
                     return user;
                 })
-                .orElseGet(() -> createUser(email,nickname,profileImgUrl));
+                .orElseGet(() -> createUser(email,socialId,nickname,profileImgUrl)); //이거는 왜 유저 도메인에 안넣음
     }
 
-    private User createUser(String email, String nickname, String profileImgUrl) {
+    private User createUser(String email, String socialId, String nickname, String profileImgUrl) {
         User createdUser = User.builder()
-                .socialId(email)
+                .email(email)
+                .socialId(socialId)
                 .nickname(nickname)
                 .profileImgUrl(profileImgUrl)
                 .build();
 
         return userRepository.save(createdUser);
     }
-
-
 
 }

--- a/src/main/java/kyonggi/bookslyserver/domain/user/service/UserService.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/service/UserService.java
@@ -34,7 +34,7 @@ public class UserService {
                     user.updateUserInfo(nickname, profileImgUrl);
                     return user;
                 })
-                .orElseGet(() -> createUser(email,socialId,nickname,profileImgUrl)); //이거는 왜 유저 도메인에 안넣음
+                .orElseGet(() -> createUser(email,socialId,nickname,profileImgUrl));
     }
 
     private User createUser(String email, String socialId, String nickname, String profileImgUrl) {

--- a/src/main/java/kyonggi/bookslyserver/global/auth/principal/PrincipalOAuth2UserService.java
+++ b/src/main/java/kyonggi/bookslyserver/global/auth/principal/PrincipalOAuth2UserService.java
@@ -25,10 +25,10 @@ public class PrincipalOAuth2UserService extends DefaultOAuth2UserService {
 
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
-        //registrationId = google
-        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        //providerId = google, naver, kakao
+        String providerId = userRequest.getClientRegistration().getRegistrationId();
         //리소스 서버로부터 받아온 attributes로 userInfo 생성
-        OAuth2UserInfo userInfo = OAuthAttributes.of(registrationId, oAuth2User.getAttributes());
+        OAuth2UserInfo userInfo = OAuthAttributes.of(providerId, oAuth2User.getAttributes());
         User user = userService.getOrCreateUser(userInfo);
 
         return new PrincipalDetails(user, oAuth2User.getAttributes());

--- a/src/main/java/kyonggi/bookslyserver/global/auth/principal/userInfo/OAuth2UserInfo.java
+++ b/src/main/java/kyonggi/bookslyserver/global/auth/principal/userInfo/OAuth2UserInfo.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class OAuth2UserInfo {
+    private final String idByProvider;
     private final String nickname;
     private final String profileImgUrl;
     private final String email;

--- a/src/main/java/kyonggi/bookslyserver/global/auth/principal/userInfo/OAuthAttributes.java
+++ b/src/main/java/kyonggi/bookslyserver/global/auth/principal/userInfo/OAuthAttributes.java
@@ -7,35 +7,48 @@ import java.util.function.Function;
 public enum OAuthAttributes {
 
     GOOGLE("google",attributes-> new OAuth2UserInfo(
+            "google_"+ attributes.get("sub").toString(),
             attributes.get("name").toString(),
             attributes.get("picture").toString(),
             attributes.get("email").toString()
     )),
 
+    NAVER("naver", attributes -> {
+
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        return new OAuth2UserInfo(
+                "naver_"+ response.get("id").toString(),
+                response.get("name").toString(),
+                response.get("profile_image").toString(),
+                response.get("email").toString()
+        );
+    }),
+
+
 //    KAKAO("kakao", attributes -> {
 //        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
 //        Map<String, Object> profile = (Map<String, Object>) attributes.get("properties");
 //        return new OAuth2UserInfo(
+//                attributes.get("id").toString(),
 //                profile.get("nickname").toString(),
 //                profile.get("profile_image").toString(),
 //                account.get("email").toString()
 //        );
 //    })
     ;
-    private final String registrationId;
+    private final String providerId;
     private final Function<Map<String, Object>, OAuth2UserInfo> of;
 
-    OAuthAttributes(String registrationId, Function<Map<String, Object>, OAuth2UserInfo> of) {
-        this.registrationId = registrationId;
+    OAuthAttributes(String providerId, Function<Map<String, Object>, OAuth2UserInfo> of) {
+        this.providerId = providerId;
         this.of = of;
     }
 
     public static OAuth2UserInfo of(String providerId, Map<String, Object> attributes) {
         return Arrays.stream(values())
-                .filter(provider -> provider.registrationId.equals(providerId))
+                .filter(oauthProvider -> oauthProvider.providerId.equals(providerId))
                 .findFirst()
                 .orElseThrow(IllegalArgumentException::new)
                 .of.apply(attributes);
     }
-
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close : #6 

## 📝작업 내용
- 간편 네이버 로그인 기능을 추가하였습니다.
- OAuth provider가 늘어남에 따라 발생할 수 있는 이메일 중복 문제를 인식하였습니다.
- 따라서 이메일을 소셜 아이디로 저장하던 기존 방식에서  OAuth provider가 제공하는 사용자 식별자를 소셜 아이디로 저장하여 이메일 중복 문제를 해결하였습니다.