### PR TITLE
[feat] #14 본인인증을 위한 인증 코드 문자 발송 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,17 +23,24 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// spring security
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 
 	// jwt
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 	implementation 'com.auth0:java-jwt:4.4.0'
+
+	// coolSMS 문자 인증
+	implementation 'net.nurigo:sdk:4.3.0'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/kyonggi/bookslyserver/domain/user/controller/UserAuthController.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/controller/UserAuthController.java
@@ -1,0 +1,40 @@
+package kyonggi.bookslyserver.domain.user.controller;
+
+import jakarta.validation.Valid;
+import kyonggi.bookslyserver.domain.user.dto.request.SendSMSRequestDto;
+import kyonggi.bookslyserver.domain.user.dto.response.SendSMSResponseDto;
+import kyonggi.bookslyserver.domain.user.service.UserAuthService;
+import kyonggi.bookslyserver.global.auth.UserId;
+import kyonggi.bookslyserver.global.common.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@RestController
+@Validated
+@Slf4j
+public class UserAuthController {
+
+    private final UserAuthService userAuthService;
+
+    @PostMapping("/owner")
+    public ResponseEntity<SuccessResponse<?>> sendSMSToOwner(@RequestBody @Valid SendSMSRequestDto sendSMSRequestDto) {
+        SendSMSResponseDto sendSMSResponseDto = userAuthService.sendMessage(sendSMSRequestDto);
+
+        return SuccessResponse.ok(sendSMSResponseDto);
+    }
+
+    @PostMapping("/user")
+    public ResponseEntity<SuccessResponse<?>> sendSMSToUser(@UserId Long userId, @RequestBody @Valid SendSMSRequestDto sendSMSRequestDto) {
+        SendSMSResponseDto sendSMSResponseDto = userAuthService.sendMessageToUser(userId, sendSMSRequestDto);
+
+        return SuccessResponse.ok(sendSMSResponseDto);
+    }
+}

--- a/src/main/java/kyonggi/bookslyserver/domain/user/controller/UserController.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/controller/UserController.java
@@ -5,9 +5,7 @@ import kyonggi.bookslyserver.global.common.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
@@ -17,12 +15,14 @@ public class UserController {
 
 
     @GetMapping("/test")
+
     public ResponseEntity<SuccessResponse<?>> test() {
         return SuccessResponse.ok("임시 리다이렉트 페이지");
     }
 
     @GetMapping("/need-login")
     public ResponseEntity<SuccessResponse<?>> needLogin(@UserId Long userId) {
-        return SuccessResponse.ok("유저 아이디 = "+userId );
+        return SuccessResponse.ok("유저 아이디 = " + userId);
     }
+
 }

--- a/src/main/java/kyonggi/bookslyserver/domain/user/dto/request/SendSMSRequestDto.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/dto/request/SendSMSRequestDto.java
@@ -1,0 +1,8 @@
+package kyonggi.bookslyserver.domain.user.dto.request;
+
+import kyonggi.bookslyserver.domain.user.validation.annotation.VerifyPhoneNum;
+
+public record SendSMSRequestDto(
+        @VerifyPhoneNum String receivingNumber
+) {
+}

--- a/src/main/java/kyonggi/bookslyserver/domain/user/dto/request/TempUserRequestDto.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/dto/request/TempUserRequestDto.java
@@ -1,4 +1,0 @@
-package kyonggi.bookslyserver.domain.user.dto.request;
-
-public record TempUserRequestDto() {
-}

--- a/src/main/java/kyonggi/bookslyserver/domain/user/dto/response/SendSMSResponseDto.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/dto/response/SendSMSResponseDto.java
@@ -1,0 +1,12 @@
+package kyonggi.bookslyserver.domain.user.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record SendSMSResponseDto(
+        String sendFrom,
+        String sendTo,
+        String statusCode,
+        String statusMessage
+) {
+}

--- a/src/main/java/kyonggi/bookslyserver/domain/user/dto/response/TempUserResponseDto.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/dto/response/TempUserResponseDto.java
@@ -1,4 +1,0 @@
-package kyonggi.bookslyserver.domain.user.dto.response;
-
-public record TempUserResponseDto() {
-}

--- a/src/main/java/kyonggi/bookslyserver/domain/user/service/UserAuthService.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/service/UserAuthService.java
@@ -3,7 +3,7 @@ package kyonggi.bookslyserver.domain.user.service;
 import kyonggi.bookslyserver.domain.user.dto.request.SendSMSRequestDto;
 import kyonggi.bookslyserver.domain.user.dto.response.SendSMSResponseDto;
 import kyonggi.bookslyserver.domain.user.repository.UserRepository;
-import kyonggi.bookslyserver.domain.user.util.AuthUtil;
+import kyonggi.bookslyserver.global.util.AuthUtil;
 import kyonggi.bookslyserver.global.error.ErrorCode;
 import kyonggi.bookslyserver.global.error.exception.CustomNurigoException;
 import kyonggi.bookslyserver.global.error.exception.EntityNotFoundException;

--- a/src/main/java/kyonggi/bookslyserver/domain/user/service/UserAuthService.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/service/UserAuthService.java
@@ -1,0 +1,48 @@
+package kyonggi.bookslyserver.domain.user.service;
+
+import kyonggi.bookslyserver.domain.user.dto.request.SendSMSRequestDto;
+import kyonggi.bookslyserver.domain.user.dto.response.SendSMSResponseDto;
+import kyonggi.bookslyserver.domain.user.repository.UserRepository;
+import kyonggi.bookslyserver.domain.user.util.AuthUtil;
+import kyonggi.bookslyserver.global.error.ErrorCode;
+import kyonggi.bookslyserver.global.error.exception.CustomNurigoException;
+import kyonggi.bookslyserver.global.error.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import net.nurigo.sdk.message.exception.NurigoBadRequestException;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserAuthService {
+
+    private final UserRepository userRepository;
+    private final AuthUtil authUtil;
+
+    public SendSMSResponseDto sendMessage(SendSMSRequestDto sendSMSRequestDto) {
+
+        String receivingNumber = sendSMSRequestDto.receivingNumber();
+        int authCode = authUtil.createAuthCode();
+
+        SingleMessageSentResponse messageSentResponse = null;
+
+        try {
+            messageSentResponse = authUtil.sendOneSMS(receivingNumber, authCode);
+        } catch (NurigoBadRequestException e) {
+            throw new CustomNurigoException();
+        }
+
+        return SendSMSResponseDto.builder()
+                .statusCode(messageSentResponse.getStatusCode())
+                .sendTo(messageSentResponse.getTo())
+                .sendFrom(messageSentResponse.getFrom())
+                .statusMessage(messageSentResponse.getStatusMessage()).build();
+    }
+
+    public SendSMSResponseDto sendMessageToUser(Long userId, SendSMSRequestDto sendSMSRequestDto) {
+
+        userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        return sendMessage(sendSMSRequestDto);
+    }
+}

--- a/src/main/java/kyonggi/bookslyserver/domain/user/service/UserAuthService.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/service/UserAuthService.java
@@ -7,6 +7,7 @@ import kyonggi.bookslyserver.global.util.AuthUtil;
 import kyonggi.bookslyserver.global.error.ErrorCode;
 import kyonggi.bookslyserver.global.error.exception.CustomNurigoException;
 import kyonggi.bookslyserver.global.error.exception.EntityNotFoundException;
+import kyonggi.bookslyserver.global.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import net.nurigo.sdk.message.exception.NurigoBadRequestException;
 import net.nurigo.sdk.message.response.SingleMessageSentResponse;
@@ -18,6 +19,7 @@ public class UserAuthService {
 
     private final UserRepository userRepository;
     private final AuthUtil authUtil;
+    private final RedisUtil redisUtil;
 
     public SendSMSResponseDto sendMessage(SendSMSRequestDto sendSMSRequestDto) {
 
@@ -31,6 +33,9 @@ public class UserAuthService {
         } catch (NurigoBadRequestException e) {
             throw new CustomNurigoException();
         }
+
+        //인증 시간 5분 설정
+        redisUtil.setDataExpire(String.valueOf(authCode), receivingNumber,  60 * 5L);
 
         return SendSMSResponseDto.builder()
                 .statusCode(messageSentResponse.getStatusCode())

--- a/src/main/java/kyonggi/bookslyserver/domain/user/util/AuthUtil.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/util/AuthUtil.java
@@ -1,0 +1,52 @@
+package kyonggi.bookslyserver.domain.user.util;
+
+import jakarta.annotation.PostConstruct;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.exception.NurigoApiKeyException;
+import net.nurigo.sdk.message.exception.NurigoBadRequestException;
+import net.nurigo.sdk.message.exception.NurigoException;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@Component
+public class AuthUtil {
+
+    @Value("${coolsms.api.key}")
+    private String apiKey;
+    @Value("${coolsms.api.secret}")
+    private String apiSecretKey;
+    @Value("${coolsms.sendFrom.phoneNum}")
+    private String sendFromNum;
+
+    private DefaultMessageService messageService;
+
+    @PostConstruct
+    private void init(){
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecretKey, "https://api.coolsms.co.kr");
+    }
+
+    public SingleMessageSentResponse sendOneSMS(String to, int authenticationCode) throws NurigoBadRequestException {
+        Message message = new Message();
+
+        // 발신번호 및 수신번호는 반드시 01012345678 형태로 입력되어야 합니다.
+        message.setFrom(sendFromNum);
+        message.setTo(to);
+        message.setText("[booksly] 아래의 인증번호를 입력해주세요\n" + authenticationCode);
+
+        SingleMessageSentResponse response = this.messageService.sendOne(new SingleMessageSendingRequest(message));
+        return response;
+    }
+
+    public int createAuthCode() {
+        Random generator = new Random();
+        generator.setSeed(System.currentTimeMillis());
+        return generator.nextInt(1000000) % 1000000;
+    }
+
+}

--- a/src/main/java/kyonggi/bookslyserver/domain/user/validation/annotation/VerifyPhoneNum.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/validation/annotation/VerifyPhoneNum.java
@@ -1,0 +1,17 @@
+package kyonggi.bookslyserver.domain.user.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import kyonggi.bookslyserver.domain.user.validation.validator.VerifyPhoneNumValidator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = VerifyPhoneNumValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface VerifyPhoneNum {
+    String message() default "전화번호 입력란에는 01012345678과 같은 형태만 입력가능합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/kyonggi/bookslyserver/domain/user/validation/validator/VerifyPhoneNumValidator.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/validation/validator/VerifyPhoneNumValidator.java
@@ -1,0 +1,37 @@
+package kyonggi.bookslyserver.domain.user.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import kyonggi.bookslyserver.domain.user.validation.annotation.VerifyPhoneNum;
+import kyonggi.bookslyserver.global.error.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class VerifyPhoneNumValidator implements ConstraintValidator<VerifyPhoneNum, String> {
+    @Override
+    public void initialize(VerifyPhoneNum constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(String phoneNumber, ConstraintValidatorContext context) {
+
+        if (phoneNumber.contains("-")) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorCode.HYPHEN_BAD_REQUEST.getMessage()).addConstraintViolation();
+            log.info("하이픈페이~");
+            return false;
+        }
+
+        // 전화번호 길이 검사
+        if(!(phoneNumber.length() == 10 || phoneNumber.length() == 11)) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorCode.PHONE_NUM_LENGTH_BAD_REQUEST.getMessage()).addConstraintViolation();
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/kyonggi/bookslyserver/domain/user/validation/validator/VerifyPhoneNumValidator.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/validation/validator/VerifyPhoneNumValidator.java
@@ -21,7 +21,6 @@ public class VerifyPhoneNumValidator implements ConstraintValidator<VerifyPhoneN
         if (phoneNumber.contains("-")) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(ErrorCode.HYPHEN_BAD_REQUEST.getMessage()).addConstraintViolation();
-            log.info("하이픈페이~");
             return false;
         }
 

--- a/src/main/java/kyonggi/bookslyserver/global/config/RedisConfig.java
+++ b/src/main/java/kyonggi/bookslyserver/global/config/RedisConfig.java
@@ -1,0 +1,39 @@
+package kyonggi.bookslyserver.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private String redisPort;
+
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(redisHost);
+        redisStandaloneConfiguration.setPort(Integer.parseInt(redisPort));
+        LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(redisStandaloneConfiguration);
+        return lettuceConnectionFactory;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/kyonggi/bookslyserver/global/error/ErrorCode.java
+++ b/src/main/java/kyonggi/bookslyserver/global/error/ErrorCode.java
@@ -13,6 +13,9 @@ public enum ErrorCode {
      * 400 Bad Request
      */
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    NURIGO_BAD_REQUEST(HttpStatus.BAD_REQUEST, "본인 인증 요청 정보를 다시 확인해주세요."),
+    HYPHEN_BAD_REQUEST(HttpStatus.BAD_REQUEST, "하이픈을 제외한 숫자만 입력해주세요"),
+    PHONE_NUM_LENGTH_BAD_REQUEST(HttpStatus.BAD_REQUEST,"핸드폰 번호는 10자리 또는 11자리만 입력 가능합니다."),
 
 
     /**

--- a/src/main/java/kyonggi/bookslyserver/global/error/dto/ErrorResponse.java
+++ b/src/main/java/kyonggi/bookslyserver/global/error/dto/ErrorResponse.java
@@ -13,11 +13,20 @@ import lombok.Getter;
 public class ErrorResponse {
     private int status;
     private String message;
+    private Object result;
 
     public static ErrorResponse of(ErrorCode errorCode) {
         return ErrorResponse.builder()
                 .status(errorCode.getHttpStatus().value())
                 .message(errorCode.getMessage())
+                .build();
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, Object result) {
+        return ErrorResponse.builder()
+                .status(errorCode.getHttpStatus().value())
+                .message(errorCode.getMessage())
+                .result(result)
                 .build();
     }
 }

--- a/src/main/java/kyonggi/bookslyserver/global/error/exception/CustomNurigoException.java
+++ b/src/main/java/kyonggi/bookslyserver/global/error/exception/CustomNurigoException.java
@@ -1,0 +1,13 @@
+package kyonggi.bookslyserver.global.error.exception;
+
+import kyonggi.bookslyserver.global.error.ErrorCode;
+
+public class CustomNurigoException extends BusinessException {
+    public CustomNurigoException() {
+        super(ErrorCode.NURIGO_BAD_REQUEST);
+    }
+
+    public CustomNurigoException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/kyonggi/bookslyserver/global/util/AuthUtil.java
+++ b/src/main/java/kyonggi/bookslyserver/global/util/AuthUtil.java
@@ -1,4 +1,4 @@
-package kyonggi.bookslyserver.domain.user.util;
+package kyonggi.bookslyserver.global.util;
 
 import jakarta.annotation.PostConstruct;
 import net.nurigo.sdk.NurigoApp;

--- a/src/main/java/kyonggi/bookslyserver/global/util/RedisUtil.java
+++ b/src/main/java/kyonggi/bookslyserver/global/util/RedisUtil.java
@@ -1,0 +1,20 @@
+package kyonggi.bookslyserver.global.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    public void setDataExpire(String key, String value, long duration) {
+        ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(duration);
+        valueOperations.set(key, value, expireDuration);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- close : #14 

## 📝작업 내용

- 회원인증에 필요한 인증코드를 담은 문자 발송 기능을 구현하였습니다. 문자 발송 시 인증코드는 5분의 유효기간이 설정되어 Redis DB에 저장됩니다.
