### PR TITLE
[fix] #21 redis 환경변수 접근 이름 오류 수정

### DIFF
--- a/src/main/java/kyonggi/bookslyserver/global/config/RedisConfig.java
+++ b/src/main/java/kyonggi/bookslyserver/global/config/RedisConfig.java
@@ -12,10 +12,10 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
+    @Value("${spring.data.redis.host}")
     private String redisHost;
 
-    @Value("${spring.redis.port}")
+    @Value("${spring.data.redis.port}")
     private String redisPort;
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- close : #21 

## 📝작업 내용

- 환경변수 접근 이름을 다음과 같이 올바르게 수정하였습니다.
- spring.data.redis.host
- spring.data.redis.port
