### PR TITLE
[feat] #40 직원 근무시간 별 예약일정 생성 기능 구현

### DIFF
--- a/src/main/java/kyonggi/bookslyserver/domain/reservation/controller/ShopOwnerReserveController.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/reservation/controller/ShopOwnerReserveController.java
@@ -17,4 +17,12 @@ public class ShopOwnerReserveController {
             (@RequestParam("shopId")Long shopId, @ModelAttribute ReserveRequestDTO.reserveSettingRequestDTO request){
         return SuccessResponse.created(reserveCommandService.setReservationSetting(request,shopId));
     }
+    
+    /*
+    * 임시 uri api 테스트 시에만 사용 바람
+    */
+    @GetMapping("/createResSch")
+    public ResponseEntity<SuccessResponse<?>> createReservationSchedule(@RequestParam("employeeId")Long employeeId){
+        return SuccessResponse.created(reserveCommandService.createEmployeeReservationSchedule(employeeId));
+    }
 }

--- a/src/main/java/kyonggi/bookslyserver/domain/reservation/converter/ReservationConverter.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/reservation/converter/ReservationConverter.java
@@ -2,8 +2,14 @@ package kyonggi.bookslyserver.domain.reservation.converter;
 
 import kyonggi.bookslyserver.domain.reservation.dto.ReserveRequestDTO;
 import kyonggi.bookslyserver.domain.reservation.dto.ReserveResponseDTO;
+import kyonggi.bookslyserver.domain.reservation.entity.ReservationSchedule;
 import kyonggi.bookslyserver.domain.reservation.entity.ReservationSetting;
+import kyonggi.bookslyserver.domain.shop.entity.Employee.Employee;
 import lombok.RequiredArgsConstructor;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 @RequiredArgsConstructor
 public class ReservationConverter {
@@ -30,6 +36,14 @@ public class ReservationConverter {
         return ReserveResponseDTO.reservationSettingResultDTO.builder()
                 .shopId(reservationSetting.getShop().getId())
                 .reservationSettingId(reservationSetting.getId())
+                .build();
+    }
+    public static ReservationSchedule toReservationSchedule(LocalTime startTime, LocalDate finalDate, Duration interval, Employee employee){
+        return ReservationSchedule.builder()
+                .startTime(startTime)
+                .endTime(startTime.plus(interval))
+                .workDate(finalDate)
+                .employee(employee)
                 .build();
     }
 }

--- a/src/main/java/kyonggi/bookslyserver/domain/reservation/repository/ReservationScheduleRepository.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/reservation/repository/ReservationScheduleRepository.java
@@ -1,0 +1,7 @@
+package kyonggi.bookslyserver.domain.reservation.repository;
+
+import kyonggi.bookslyserver.domain.reservation.entity.ReservationSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationScheduleRepository extends JpaRepository<ReservationSchedule,Long> {
+}

--- a/src/main/java/kyonggi/bookslyserver/domain/shop/repository/EmployeeRepository.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/shop/repository/EmployeeRepository.java
@@ -1,0 +1,8 @@
+package kyonggi.bookslyserver.domain.shop.repository;
+
+import kyonggi.bookslyserver.domain.shop.entity.Employee.Employee;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmployeeRepository extends JpaRepository<Employee,Long> {
+
+}

--- a/src/main/java/kyonggi/bookslyserver/global/error/ErrorCode.java
+++ b/src/main/java/kyonggi/bookslyserver/global/error/ErrorCode.java
@@ -50,7 +50,7 @@ public enum ErrorCode implements BaseErrorCode{
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 회원입니다."),
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "엔티티를 찾을 수 없습니다."),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND,"요청한 리소스를 찾을 수 없습니다."),
-
+    SETTING_NOT_FOUND(HttpStatus.NOT_FOUND,"예약 설정을 먼저 완료해주세요"),
 
     /**
      * 405 Method Not Allowed


### PR DESCRIPTION
## #️⃣연관된 이슈

- close : #40 

## 📝작업 내용

> 직원 WorkSchedule과 가게 ReservationSetting에 따라 직원별 예약 일정을 생성하는 로직을 구현하였습니다.
   
## 💬리뷰 요구사항

> 현재 api 테스트를 위해 컨트롤러에 uri가 작성되어 있는데 추후 직원 등록 api가 완성되면 직원 등록 후 서비스 레벨의 메소드 호출 부탁드립니다.
