### PR TITLE
[feat] #98 마감이벤트 설정기능 구현 

### DIFF
--- a/src/main/java/kyonggi/bookslyserver/domain/event/controller/EventController.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/event/controller/EventController.java
@@ -23,7 +23,7 @@ public class EventController {
     private final TimeEventService timeEventService;
     private final ClosingEventService closingEventService;
 
-    @PostMapping("/time-event")
+    @PostMapping("/time-events")
     public ResponseEntity<SuccessResponse<?>> createTimeEvents(@OwnerId Long ownerId, @RequestBody CreateTimeEventsRequestDto createTimeEventsRequestDto){
         CreateTimeEventsResponseDto timeEventsResponseDto = timeEventService.createTimeEvents(ownerId, createTimeEventsRequestDto);
         return SuccessResponse.ok(timeEventsResponseDto);

--- a/src/main/java/kyonggi/bookslyserver/domain/event/controller/EventController.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/event/controller/EventController.java
@@ -1,17 +1,18 @@
 package kyonggi.bookslyserver.domain.event.controller;
 
+import kyonggi.bookslyserver.domain.event.dto.request.CreateClosingEventRequestDto;
 import kyonggi.bookslyserver.domain.event.dto.request.CreateTimeEventsRequestDto;
+import kyonggi.bookslyserver.domain.event.dto.response.CreateClosingEventResponseDto;
 import kyonggi.bookslyserver.domain.event.dto.response.CreateTimeEventsResponseDto;
+import kyonggi.bookslyserver.domain.event.repository.ClosingEventRepository;
+import kyonggi.bookslyserver.domain.event.service.ClosingEventService;
 import kyonggi.bookslyserver.domain.event.service.TimeEventService;
 import kyonggi.bookslyserver.global.auth.principal.shopOwner.OwnerId;
 import kyonggi.bookslyserver.global.common.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,10 +21,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class EventController {
 
     private final TimeEventService timeEventService;
+    private final ClosingEventService closingEventService;
 
     @PostMapping("/time-event")
     public ResponseEntity<SuccessResponse<?>> createTimeEvents(@OwnerId Long ownerId, @RequestBody CreateTimeEventsRequestDto createTimeEventsRequestDto){
         CreateTimeEventsResponseDto timeEventsResponseDto = timeEventService.createTimeEvents(ownerId, createTimeEventsRequestDto);
         return SuccessResponse.ok(timeEventsResponseDto);
+    }
+
+    @PostMapping("/closing-events")
+    public ResponseEntity<SuccessResponse<?>> createClosingEvent(@RequestBody CreateClosingEventRequestDto createClosingEventRequestDto) {
+        CreateClosingEventResponseDto createClosingEventResponseDto = closingEventService.createClosingEvent(createClosingEventRequestDto);
+        return SuccessResponse.created(createClosingEventResponseDto);
     }
 }

--- a/src/main/java/kyonggi/bookslyserver/domain/event/dto/request/CreateClosingEventRequestDto.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/event/dto/request/CreateClosingEventRequestDto.java
@@ -9,6 +9,6 @@ public record CreateClosingEventRequestDto(
         @NotNull Long employeeId,
         @NotNull String message,
         @NotNull int discountRate,
-        @NotNull List<Long> menus
+        @NotNull List<Long> menuIds
 ) {
 }

--- a/src/main/java/kyonggi/bookslyserver/domain/event/dto/request/CreateClosingEventRequestDto.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/event/dto/request/CreateClosingEventRequestDto.java
@@ -7,7 +7,7 @@ import java.util.List;
 public record CreateClosingEventRequestDto(
         @NotNull Long shopId,
         @NotNull Long employeeId,
-        @NotNull String content,
+        @NotNull String message,
         @NotNull int discountRate,
         @NotNull List<Long> menus
 ) {

--- a/src/main/java/kyonggi/bookslyserver/domain/event/dto/request/CreateClosingEventRequestDto.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/event/dto/request/CreateClosingEventRequestDto.java
@@ -1,0 +1,14 @@
+package kyonggi.bookslyserver.domain.event.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record CreateClosingEventRequestDto(
+        @NotNull Long shopId,
+        @NotNull Long employeeId,
+        @NotNull String content,
+        @NotNull int discountRate,
+        @NotNull List<Long> menus
+) {
+}

--- a/src/main/java/kyonggi/bookslyserver/domain/event/dto/response/CreateClosingEventResponseDto.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/event/dto/response/CreateClosingEventResponseDto.java
@@ -1,0 +1,13 @@
+package kyonggi.bookslyserver.domain.event.dto.response;
+
+import kyonggi.bookslyserver.domain.event.entity.closeEvent.ClosingEvent;
+import lombok.Builder;
+
+@Builder
+public record CreateClosingEventResponseDto(
+        Long eventId
+) {
+    public static CreateClosingEventResponseDto of(ClosingEvent closingEvent) {
+        return CreateClosingEventResponseDto.builder().eventId(closingEvent.getId()).build();
+    }
+}

--- a/src/main/java/kyonggi/bookslyserver/domain/event/entity/closeEvent/ClosingEvent.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/event/entity/closeEvent/ClosingEvent.java
@@ -23,11 +23,7 @@ public class ClosingEvent extends BaseTimeEntity {
 
     private int discountRate;
 
-    private boolean isAutoConfirm;
-
     private String eventMessage;
-
-    private int concurrentBookingLimit;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "employee_id")
@@ -36,6 +32,4 @@ public class ClosingEvent extends BaseTimeEntity {
     @OneToMany(mappedBy = "closingEvent", cascade = CascadeType.ALL)
     private List<ClosingEventMenu> closingEventMenus = new ArrayList<>();
 
-    @OneToMany(mappedBy = "closingEvent")
-    private List<ReservationSchedule> reservationSchedules = new ArrayList<>();
 }

--- a/src/main/java/kyonggi/bookslyserver/domain/event/entity/closeEvent/ClosingEvent.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/event/entity/closeEvent/ClosingEvent.java
@@ -30,6 +30,6 @@ public class ClosingEvent extends BaseTimeEntity {
     private Employee employee;
 
     @OneToMany(mappedBy = "closingEvent", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<ClosingEventMenu> closingEventMenus = new ArrayList<>();
-
 }

--- a/src/main/java/kyonggi/bookslyserver/domain/event/entity/closeEvent/ClosingEventMenu.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/event/entity/closeEvent/ClosingEventMenu.java
@@ -26,4 +26,10 @@ public class ClosingEventMenu extends BaseTimeEntity {
     @JoinColumn(name = "menu_id")
     private Menu menu;
 
+    //== 연관관계 편의 메서드 ==//
+    public void addClosingEvent(ClosingEvent closingEvent) {
+        this.closingEvent = closingEvent;
+        closingEvent.getClosingEventMenus().add(this);
+    }
+
 }

--- a/src/main/java/kyonggi/bookslyserver/domain/event/service/ClosingEventService.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/event/service/ClosingEventService.java
@@ -1,5 +1,8 @@
 package kyonggi.bookslyserver.domain.event.service;
 
+import kyonggi.bookslyserver.domain.event.dto.request.CreateClosingEventRequestDto;
+import kyonggi.bookslyserver.domain.event.dto.response.CreateClosingEventResponseDto;
+import kyonggi.bookslyserver.domain.event.repository.ClosingEventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,4 +11,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class ClosingEventService {
+    private final ClosingEventRepository closingEventRepository;
+
+    public CreateClosingEventResponseDto createClosingEvent(CreateClosingEventRequestDto createClosingEventRequestDto) {
+
+        return null;
+    }
 }

--- a/src/main/java/kyonggi/bookslyserver/domain/event/service/ClosingEventService.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/event/service/ClosingEventService.java
@@ -2,19 +2,52 @@ package kyonggi.bookslyserver.domain.event.service;
 
 import kyonggi.bookslyserver.domain.event.dto.request.CreateClosingEventRequestDto;
 import kyonggi.bookslyserver.domain.event.dto.response.CreateClosingEventResponseDto;
+import kyonggi.bookslyserver.domain.event.entity.closeEvent.ClosingEvent;
+import kyonggi.bookslyserver.domain.event.entity.closeEvent.ClosingEventMenu;
 import kyonggi.bookslyserver.domain.event.repository.ClosingEventRepository;
+import kyonggi.bookslyserver.domain.shop.repository.EmployeeRepository;
+import kyonggi.bookslyserver.domain.shop.repository.MenuRepository;
+import kyonggi.bookslyserver.domain.shop.service.ShopService;
+import kyonggi.bookslyserver.global.error.ErrorCode;
+import kyonggi.bookslyserver.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static kyonggi.bookslyserver.global.error.ErrorCode.EMPLOYEE_NOT_FOUND;
+import static kyonggi.bookslyserver.global.error.ErrorCode.MENU_NOT_FOUND;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class ClosingEventService {
     private final ClosingEventRepository closingEventRepository;
+    private final MenuRepository menuRepository;
+    private final EmployeeRepository employeeRepository;
 
     public CreateClosingEventResponseDto createClosingEvent(CreateClosingEventRequestDto createClosingEventRequestDto) {
 
-        return null;
+        ClosingEvent closingEvent = ClosingEvent.builder()
+                .eventMessage(createClosingEventRequestDto.message())
+                .discountRate(createClosingEventRequestDto.discountRate())
+                .employee(employeeRepository
+                        .findById(createClosingEventRequestDto.employeeId())
+                        .orElseThrow(()->new EntityNotFoundException(EMPLOYEE_NOT_FOUND))).build();
+
+
+        createClosingEventRequestDto.menuIds().stream()
+                .map(id -> menuRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(MENU_NOT_FOUND)))
+                .forEach(menu -> {
+                    ClosingEventMenu closingEventMenu = ClosingEventMenu.builder()
+                            .menu(menu)
+                            .closingEvent(closingEvent).build();
+                    closingEventMenu.addClosingEvent(closingEvent);
+                });
+
+        ClosingEvent createdEvent = closingEventRepository.save(closingEvent);
+        return CreateClosingEventResponseDto.of(createdEvent);
     }
 }

--- a/src/main/java/kyonggi/bookslyserver/domain/event/service/TimeEventService.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/event/service/TimeEventService.java
@@ -12,6 +12,7 @@ import kyonggi.bookslyserver.domain.shop.entity.Shop.Shop;
 import kyonggi.bookslyserver.domain.shop.repository.EmployeeRepository;
 import kyonggi.bookslyserver.domain.shop.repository.MenuRepository;
 import kyonggi.bookslyserver.domain.shop.repository.ShopRepository;
+import kyonggi.bookslyserver.domain.shop.service.ShopService;
 import kyonggi.bookslyserver.global.error.ErrorCode;
 import kyonggi.bookslyserver.global.error.exception.BusinessException;
 import kyonggi.bookslyserver.global.error.exception.ConflictException;
@@ -42,9 +43,10 @@ public class TimeEventService {
     private final TimeEventRepository timeEventRepository;
     private final EmployTimeEventScheduleRepository employTimeEventScheduleRepository;
     private final ReservationScheduleRepository reservationScheduleRepository;
+    private final ShopService shopService;
 
     public CreateTimeEventsResponseDto createTimeEvents(Long ownerId, CreateTimeEventsRequestDto requestDto) {
-        Shop shop = findShop(ownerId, requestDto.shopId());
+        Shop shop = shopService.findShop(ownerId, requestDto.shopId());
 
         validateRepeatSettings(requestDto.isRepeat(), requestDto.isDateRepeat(), requestDto.isDayOfWeekRepeat());
 
@@ -304,14 +306,6 @@ public class TimeEventService {
                 .build();
 
         return timeEvent;
-    }
-
-    private Shop findShop(Long ownerId, Long shopId) {
-        Shop shop = shopRepository.findById(shopId).orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
-        if (shop.getShopOwner().getId() != ownerId) {
-            throw new BusinessException(BAD_REQUEST);
-        }
-        return shop;
     }
 
     private void setMenuAndTimeEventToTimeEventMenu(CreateTimeEventsRequestDto requestDto, TimeEvent timeEvent) {

--- a/src/main/java/kyonggi/bookslyserver/domain/shop/service/ShopService.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/shop/service/ShopService.java
@@ -13,12 +13,16 @@ import kyonggi.bookslyserver.domain.shop.repository.ShopImageRepository;
 import kyonggi.bookslyserver.domain.shop.repository.ShopRepository;
 import kyonggi.bookslyserver.domain.user.entity.ShopOwner;
 import kyonggi.bookslyserver.domain.user.repository.ShopOwnerRepository;
+import kyonggi.bookslyserver.global.error.exception.BusinessException;
 import kyonggi.bookslyserver.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
+
+import static kyonggi.bookslyserver.global.error.ErrorCode.BAD_REQUEST;
+import static kyonggi.bookslyserver.global.error.ErrorCode.ENTITY_NOT_FOUND;
 
 @Service
 @Transactional
@@ -72,8 +76,11 @@ public class ShopService {
         shopRepository.deleteById(id);
     }
 
-
-
-
-
+    public Shop findShop(Long ownerId, Long shopId) {
+        Shop shop = shopRepository.findById(shopId).orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
+        if (shop.getShopOwner().getId() != ownerId) {
+            throw new BusinessException(BAD_REQUEST);
+        }
+        return shop;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close : #98 

## 📝작업 내용

직원별로 달라지는 **마감이벤트**를 설정하는 기능을 구현하였습니다.  
마감이벤트 설정에 따라 직원의 예약 일정에서 마감이벤트 등록 가능합니다. (추후 구현)
   
## 💬리뷰 요구사항(선택)

기획 변경으로 마감이벤트 엔티티의 일부 필드를 삭제하였습니다. 이로 인해 영향을 받는 부분이 있는 지 확인 부탁드립니다!
