### PR TITLE
Feature/#183 직원별 메뉴 조회 기능(이벤트 메뉴 등록)

### DIFF
--- a/src/main/java/kyonggi/bookslyserver/domain/shop/controller/MenuApiController.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/shop/controller/MenuApiController.java
@@ -38,7 +38,7 @@ public class MenuApiController {
 
     @GetMapping("api/shops/employees/{employeeId}/menus/EventRegistration")
     public ResponseEntity<SuccessResponse<?>> readMenuNamesTimeEventRegister(@PathVariable("employeeId") Long id){
-        List<EventRegisterMenuNamesDto> result = menuService.readMenuNamesEventRegister(id);
+        List<EventRegisterEmployeeMenuDto> result = menuService.readMenuNamesEventRegister(id);
         return SuccessResponse.ok(result);
     }
 

--- a/src/main/java/kyonggi/bookslyserver/domain/shop/controller/MenuApiController.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/shop/controller/MenuApiController.java
@@ -36,7 +36,7 @@ public class MenuApiController {
         return SuccessResponse.ok(result);
     }
 
-    @GetMapping("/api/shops/employees/{employeeId}/menus/eventRegistration")
+    @GetMapping("/api/shops/employees/{employeeId}/menus/closingEventRegistration")
     public ResponseEntity<SuccessResponse<?>> readMenuNames(@PathVariable("employeeId") Long id){
         List<EventRegisterMenuNamesDto> result = menuService.readMenuNames(id);
         return SuccessResponse.ok(result);

--- a/src/main/java/kyonggi/bookslyserver/domain/shop/controller/MenuApiController.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/shop/controller/MenuApiController.java
@@ -37,11 +37,16 @@ public class MenuApiController {
     }
 
     @GetMapping("/api/shops/employees/{employeeId}/menus/closingEventRegistration")
-    public ResponseEntity<SuccessResponse<?>> readMenuNames(@PathVariable("employeeId") Long id){
-        List<EventRegisterMenuNamesDto> result = menuService.readMenuNames(id);
+    public ResponseEntity<SuccessResponse<?>> readMenuNamesClosingEventRegister(@PathVariable("employeeId") Long id){
+        List<EventRegisterMenuNamesDto> result = menuService.readMenuNamesClosingEventRegister(id);
         return SuccessResponse.ok(result);
     }
 
+    @GetMapping("api/shops/employees/{employeeId}/menus/timeEventRegistration")
+    public ResponseEntity<SuccessResponse<?>> readMenuNamesTimeEventRegister(@PathVariable("employeeId") Long id){
+        List<EventRegisterMenuNamesDto> result = menuService.readMenuNamesTimeEventRegister(id);
+        return SuccessResponse.ok(result);
+    }
 
     @PostMapping("/api/shops/{shopId}/menus")
     public ResponseEntity<SuccessResponse<?>> createMenu(@PathVariable("shopId") Long id, @RequestBody @Validated MenuCreateRequestDto requestDto){

--- a/src/main/java/kyonggi/bookslyserver/domain/shop/controller/MenuApiController.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/shop/controller/MenuApiController.java
@@ -36,15 +36,9 @@ public class MenuApiController {
         return SuccessResponse.ok(result);
     }
 
-    @GetMapping("/api/shops/employees/{employeeId}/menus/closingEventRegistration")
-    public ResponseEntity<SuccessResponse<?>> readMenuNamesClosingEventRegister(@PathVariable("employeeId") Long id){
-        List<EventRegisterMenuNamesDto> result = menuService.readMenuNamesClosingEventRegister(id);
-        return SuccessResponse.ok(result);
-    }
-
-    @GetMapping("api/shops/employees/{employeeId}/menus/timeEventRegistration")
+    @GetMapping("api/shops/employees/{employeeId}/menus/EventRegistration")
     public ResponseEntity<SuccessResponse<?>> readMenuNamesTimeEventRegister(@PathVariable("employeeId") Long id){
-        List<EventRegisterMenuNamesDto> result = menuService.readMenuNamesTimeEventRegister(id);
+        List<EventRegisterMenuNamesDto> result = menuService.readMenuNamesEventRegister(id);
         return SuccessResponse.ok(result);
     }
 

--- a/src/main/java/kyonggi/bookslyserver/domain/shop/controller/MenuApiController.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/shop/controller/MenuApiController.java
@@ -5,12 +5,7 @@ package kyonggi.bookslyserver.domain.shop.controller;
 import kyonggi.bookslyserver.domain.shop.dto.request.menu.MenuCategoryCreateDto;
 import kyonggi.bookslyserver.domain.shop.dto.request.menu.MenuCreateRequestDto;
 import com.sun.net.httpserver.Authenticator;
-import kyonggi.bookslyserver.domain.shop.dto.response.menu.MenuCategoryCreateResponseDto;
-import kyonggi.bookslyserver.domain.shop.dto.response.menu.MenuCategoryReadDto;
-import kyonggi.bookslyserver.domain.shop.dto.response.menu.MenuCreateResponseDto;
-import kyonggi.bookslyserver.domain.shop.dto.response.menu.MenuReadOneDto;
-import kyonggi.bookslyserver.domain.shop.dto.response.menu.MenuReadDto;
-import kyonggi.bookslyserver.domain.shop.dto.response.menu.MenuUpdateResponseDto;
+import kyonggi.bookslyserver.domain.shop.dto.response.menu.*;
 import kyonggi.bookslyserver.domain.shop.service.MenuService;
 import kyonggi.bookslyserver.global.common.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +33,12 @@ public class MenuApiController {
     @GetMapping("/api/shops/{shopId}/menus")
     public ResponseEntity<SuccessResponse<?>> readMenu(@PathVariable("shopId") Long id){
         List<MenuReadDto> result = menuService.readMenu(id);
+        return SuccessResponse.ok(result);
+    }
+
+    @GetMapping("/api/shops/employees/{employeeId}/menus/eventRegistration")
+    public ResponseEntity<SuccessResponse<?>> readMenuNames(@PathVariable("employeeId") Long id){
+        List<EventRegisterMenuNamesDto> result = menuService.readMenuNames(id);
         return SuccessResponse.ok(result);
     }
 

--- a/src/main/java/kyonggi/bookslyserver/domain/shop/dto/response/menu/EventRegisterEmployeeMenuDto.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/shop/dto/response/menu/EventRegisterEmployeeMenuDto.java
@@ -1,0 +1,32 @@
+package kyonggi.bookslyserver.domain.shop.dto.response.menu;
+
+import kyonggi.bookslyserver.domain.shop.entity.Menu.Menu;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class EventRegisterEmployeeMenuDto {
+    private String menuCategoryName;
+
+    private List<MenuDto> menu;
+
+    public EventRegisterEmployeeMenuDto(Menu menu){
+        this.menuCategoryName = menu.getMenuCategory().getName();
+        this.menu = new ArrayList<>();
+    }
+
+
+    @Data
+    public static class MenuDto{
+        private Long id;
+        private String menuName;
+
+        public MenuDto(Menu menu){
+            this.id = menu.getId();
+            this.menuName = menu.getMenuName();
+        }
+    }
+
+}

--- a/src/main/java/kyonggi/bookslyserver/domain/shop/dto/response/menu/EventRegisterMenuNamesDto.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/shop/dto/response/menu/EventRegisterMenuNamesDto.java
@@ -1,0 +1,19 @@
+package kyonggi.bookslyserver.domain.shop.dto.response.menu;
+
+import kyonggi.bookslyserver.domain.shop.entity.Menu.Menu;
+import lombok.Data;
+
+@Data
+public class EventRegisterMenuNamesDto {
+    private Long id;
+
+    private String menuCategoryName;
+
+    private String menuName;
+
+    public EventRegisterMenuNamesDto(Menu menu){
+        this.id = menu.getId();
+        this.menuCategoryName = menu.getMenuCategory().getName();
+        this.menuName = menu.getMenuName();
+    }
+}

--- a/src/main/java/kyonggi/bookslyserver/domain/shop/service/MenuService.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/shop/service/MenuService.java
@@ -64,7 +64,7 @@ public class MenuService {
         return menuReadDtos;
     }
 
-    public List<EventRegisterMenuNamesDto> readMenuNames(Long id){
+    public List<EventRegisterMenuNamesDto> readMenuNamesClosingEventRegister(Long id){
         Optional<Employee> employee = employeeRepository.findById(id);
         List<Menu> menus = new ArrayList<>();
         List<Menu> deletemenus = new ArrayList<>();
@@ -90,6 +90,19 @@ public class MenuService {
 
         List<EventRegisterMenuNamesDto> result = menus.stream().map(menu -> new EventRegisterMenuNamesDto(menu)).collect(Collectors.toList());
 
+        return result;
+    }
+
+    public List<EventRegisterMenuNamesDto> readMenuNamesTimeEventRegister(Long id){
+        Optional<Employee> employee = employeeRepository.findById(id);
+        List<Menu> menus = new ArrayList<>();
+        if(!employee.isPresent()){
+            throw new EntityNotFoundException(ErrorCode.EMPLOYEE_NOT_FOUND);
+        }
+        for(EmployeeMenu employeeMenu : employee.get().getEmployeeMenus()){
+            menus.add(employeeMenu.getMenu());
+        }
+        List<EventRegisterMenuNamesDto> result = menus.stream().map(menu -> new EventRegisterMenuNamesDto(menu)).collect(Collectors.toList());
         return result;
     }
 

--- a/src/main/java/kyonggi/bookslyserver/domain/shop/service/MenuService.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/shop/service/MenuService.java
@@ -64,36 +64,8 @@ public class MenuService {
         return menuReadDtos;
     }
 
-    public List<EventRegisterMenuNamesDto> readMenuNamesClosingEventRegister(Long id){
-        Optional<Employee> employee = employeeRepository.findById(id);
-        List<Menu> menus = new ArrayList<>();
-        List<Menu> deletemenus = new ArrayList<>();
-        if(!employee.isPresent()){
-            throw new EntityNotFoundException(ErrorCode.EMPLOYEE_NOT_FOUND);
-        }
 
-        for(EmployeeMenu employeeMenu : employee.get().getEmployeeMenus()){
-            menus.add(employeeMenu.getMenu());
-        }
-
-        for(Menu menu : menus){
-            for(ClosingEventMenu closingEventMenu : menu.getClosingEventMenus()){
-                if(closingEventMenu.getClosingEvent().getEmployee() == employee.get()){
-                    deletemenus.add(menu);
-                }
-            }
-        }
-
-        for(Menu menu : deletemenus){
-            menus.remove(menu);
-        }
-
-        List<EventRegisterMenuNamesDto> result = menus.stream().map(menu -> new EventRegisterMenuNamesDto(menu)).collect(Collectors.toList());
-
-        return result;
-    }
-
-    public List<EventRegisterMenuNamesDto> readMenuNamesTimeEventRegister(Long id){
+    public List<EventRegisterMenuNamesDto> readMenuNamesEventRegister(Long id){
         Optional<Employee> employee = employeeRepository.findById(id);
         List<Menu> menus = new ArrayList<>();
         if(!employee.isPresent()){

--- a/src/main/java/kyonggi/bookslyserver/domain/shop/service/MenuService.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/shop/service/MenuService.java
@@ -20,9 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.GetMapping;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -65,16 +63,34 @@ public class MenuService {
     }
 
 
-    public List<EventRegisterMenuNamesDto> readMenuNamesEventRegister(Long id){
+    public List<EventRegisterEmployeeMenuDto> readMenuNamesEventRegister(Long id){
         Optional<Employee> employee = employeeRepository.findById(id);
         List<Menu> menus = new ArrayList<>();
+        Set<EventRegisterEmployeeMenuDto> eventRegisterEmployeeMenuDtos = new HashSet<>();
+
         if(!employee.isPresent()){
             throw new EntityNotFoundException(ErrorCode.EMPLOYEE_NOT_FOUND);
         }
         for(EmployeeMenu employeeMenu : employee.get().getEmployeeMenus()){
             menus.add(employeeMenu.getMenu());
         }
-        List<EventRegisterMenuNamesDto> result = menus.stream().map(menu -> new EventRegisterMenuNamesDto(menu)).collect(Collectors.toList());
+
+        for(Menu menu : menus){
+            eventRegisterEmployeeMenuDtos.add(new EventRegisterEmployeeMenuDto(menu));
+        }
+        //System.out.println("====================================================" + eventRegisterEmployeeMenuDtos.size() + "======================================================");
+
+        List<EventRegisterEmployeeMenuDto> result = new ArrayList<>(eventRegisterEmployeeMenuDtos);
+
+        for(Menu menu : menus){
+                for(EventRegisterEmployeeMenuDto e : result){
+                    if(menu.getMenuCategory().getName().equals(e.getMenuCategoryName())){
+                        e.getMenu().add(new EventRegisterEmployeeMenuDto.MenuDto(menu));
+                    }
+                }
+        }
+
+        //List<EventRegisterMenuNamesDto> result = menus.stream().map(menu -> new EventRegisterMenuNamesDto(menu)).collect(Collectors.toList());
         return result;
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- close : #183

## 📝작업 내용

직원별 메뉴 조회 기능(이벤트 메뉴 등록)을 구현합니다.

2개의 api가 있습니다.

1. "마감 임박 이벤트" 등록 화면에 대한 직원별 메뉴 조회
![스크린샷(120)](https://github.com/Booksly/BOOKSLY-SERVER/assets/127214774/c835cf1c-6171-4ad6-a13b-b2df59fefdb1)


2. "타임 세일 이벤트" 등록 화면에 대한 직원별 메뉴 조회
![스크린샷(119)](https://github.com/Booksly/BOOKSLY-SERVER/assets/127214774/870525d7-0014-4f9a-9dd0-a3456c327ddd)


직원의 담당 메뉴는 5개가 있습니다.(testMenu1 ~ testMenu5)
직원의 담당 메뉴 중 testMenu2와 testMenu4는 마감 임박 이벤트가 설정 되어 있습니다.

### 1. "마감 임박 이벤트" 등록 화면에 대한 직원별 메뉴 조회
"마감 임박 이벤트"는 직원-담당메뉴 별 1개씩만 생성(중복 생성 불가능)이 가능하기 때문에 "마감 임박 이벤트 등록 화면" 에서는 기존에 등록 되어 있던 메뉴를 제외 한 후 조회 합니다.

### request
![스크린샷(122)](https://github.com/Booksly/BOOKSLY-SERVER/assets/127214774/17806db1-dbe1-4ec7-8bf9-2e9096bbb131)
### response
![스크린샷(123)](https://github.com/Booksly/BOOKSLY-SERVER/assets/127214774/86d856b3-092a-43e7-8afa-1137400c6f27)


기존에 등록 되어 있던 마감 임박 이벤트 메뉴의 수정은 아래의 화면에서 수행합니다.
![스크린샷(124)](https://github.com/Booksly/BOOKSLY-SERVER/assets/127214774/e7916bc4-aa3a-4d1a-8fc3-221655bc0e1e)

### 2. "타임 세일 이벤트" 등록 화면에 대한 직원별 메뉴 조회
"타임 세일 이벤트"는 직원-담당메뉴 별 중복생성이 가능하기 때문에 "타임 세일 이벤트 등록 화면"에서는 직원별 모든 메뉴를 조회 합니다. 

### request
![스크린샷(125)](https://github.com/Booksly/BOOKSLY-SERVER/assets/127214774/328f6057-97db-4dad-a053-ca27b7d52b4d)


### response

![스크린샷(127)](https://github.com/Booksly/BOOKSLY-SERVER/assets/127214774/f3fad75a-a547-4e98-9bdf-d6bea25764e7)

중복된 시간이 겹칠 시에는 "등록"버튼을 클릭 시 중복 검증이 필요합니다.

마감 임박 이벤트 메뉴와 마찬가지로 기존에 등록 되어 있던 타임 세일 이벤트 메뉴의 수정은 아래의 화면에서 수행합니다.
![스크린샷(128)](https://github.com/Booksly/BOOKSLY-SERVER/assets/127214774/d8f1acfc-edc7-4ef0-8dcd-89d5a75cd4fe)

