### PR TITLE
[refactor] #196 마감이벤트 설정 등록 시 검증 추가

### DIFF
--- a/src/main/java/kyonggi/bookslyserver/domain/event/controller/EventController.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/event/controller/EventController.java
@@ -60,8 +60,8 @@ public class EventController {
 
 
     @PostMapping("/closing-events")
-    public ResponseEntity<SuccessResponse<?>> createClosingEvent(@RequestBody CreateClosingEventRequestDto createClosingEventRequestDto) {
-        CreateClosingEventResponseDto createClosingEventResponseDto = closingEventCommandService.createClosingEvent(createClosingEventRequestDto);
+    public ResponseEntity<SuccessResponse<?>> createClosingEvent(@RequestBody CreateClosingEventRequestDto createClosingEventRequestDto, @OwnerId Long ownerId) {
+        CreateClosingEventResponseDto createClosingEventResponseDto = closingEventCommandService.createClosingEvent(createClosingEventRequestDto, ownerId);
         return SuccessResponse.created(createClosingEventResponseDto);
     }
 

--- a/src/main/java/kyonggi/bookslyserver/domain/shop/repository/EmployeeMenuRepository.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/shop/repository/EmployeeMenuRepository.java
@@ -1,7 +1,9 @@
 package kyonggi.bookslyserver.domain.shop.repository;
 
 import jakarta.transaction.Transactional;
+import kyonggi.bookslyserver.domain.shop.entity.Employee.Employee;
 import kyonggi.bookslyserver.domain.shop.entity.Employee.EmployeeMenu;
+import kyonggi.bookslyserver.domain.shop.entity.Menu.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -19,4 +21,8 @@ public interface EmployeeMenuRepository extends JpaRepository<EmployeeMenu,Long>
     @Transactional
     @Query("select em from EmployeeMenu em where em.employee.id = :employee_id")
     List<EmployeeMenu> findByEmployeeId(@Param("employee_id") Long id);
+
+    @Query("SELECT COUNT(em) "+
+            "FROM EmployeeMenu em WHERE em.employee = :employee_id AND em.menu IN :menus")
+    int findByMenuAndEmployee(@Param("menus") List<Menu> menus, @Param("employee_id") Employee employee);
 }

--- a/src/main/java/kyonggi/bookslyserver/domain/shop/repository/EmployeeRepository.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/shop/repository/EmployeeRepository.java
@@ -19,4 +19,8 @@ public interface EmployeeRepository extends JpaRepository<Employee,Long> {
     @Transactional
     @Query("select e from Employee e where e.shop.id = :shopId")
     List<Employee> findEmployeesByShopId(@Param("shopId") Long id);
+
+    @Query("SELECT CASE WHEN COUNT(e) > 0 THEN true ELSE false END " +
+            "FROM Employee e WHERE e.id = :employeeId AND e.shop.id = :shopId")
+    boolean existsByIdAndShopId(@Param("employeeId") Long employeeId, @Param("shopId") Long shopId);
 }

--- a/src/main/java/kyonggi/bookslyserver/domain/shop/service/ShopService.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/shop/service/ShopService.java
@@ -18,6 +18,7 @@ import kyonggi.bookslyserver.domain.user.repository.ShopOwnerRepository;
 import kyonggi.bookslyserver.global.error.ErrorCode;
 import kyonggi.bookslyserver.global.error.exception.BusinessException;
 import kyonggi.bookslyserver.global.error.exception.EntityNotFoundException;
+import kyonggi.bookslyserver.global.error.exception.InvalidValueException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -159,7 +160,7 @@ public class ShopService {
     public Shop findShop(Long ownerId, Long shopId) {
         Shop shop = shopRepository.findById(shopId).orElseThrow(() -> new EntityNotFoundException(SHOP_NOT_FOUND));
         if (shop.getShopOwner().getId() != ownerId) {
-            throw new BusinessException(BAD_REQUEST);
+            throw new InvalidValueException(NOT_OWNER_OF_SHOP);
         }
         return shop;
     }

--- a/src/main/java/kyonggi/bookslyserver/global/error/ErrorCode.java
+++ b/src/main/java/kyonggi/bookslyserver/global/error/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode implements BaseErrorCode{
     START_TIME_IS_AFTER_END_TIME(HttpStatus.BAD_REQUEST,"이벤트 시작 시간은 이벤트 마감 시간 이전이어야 합니다."),
     START_DATE_IS_AFTER_END_DATE(HttpStatus.BAD_REQUEST,"이벤트 시작일은 이벤트 마감일 이전이어야 합니다."),
     MENU_IS_NOT_EMPLOYEEMENU(HttpStatus.BAD_REQUEST,"직원 담당 메뉴가 아닌 메뉴가 존재합니다."),
+    EMPLOYEE_NOT_BELONG_SHOP(HttpStatus.BAD_REQUEST,"요청 가게에 속한 직원이 아닙니다."),
 
 
     /**

--- a/src/main/java/kyonggi/bookslyserver/global/error/ErrorCode.java
+++ b/src/main/java/kyonggi/bookslyserver/global/error/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode implements BaseErrorCode{
     START_DATE_IS_AFTER_END_DATE(HttpStatus.BAD_REQUEST,"이벤트 시작일은 이벤트 마감일 이전이어야 합니다."),
     MENU_IS_NOT_EMPLOYEEMENU(HttpStatus.BAD_REQUEST,"직원 담당 메뉴가 아닌 메뉴가 존재합니다."),
     EMPLOYEE_NOT_BELONG_SHOP(HttpStatus.BAD_REQUEST,"요청 가게에 속한 직원이 아닙니다."),
+    NOT_OWNER_OF_SHOP(HttpStatus.BAD_REQUEST,"해당 가게의 주인이 아닙니다."),
 
 
     /**


### PR DESCRIPTION
## #️⃣연관된 이슈

- close : #196 

## 📝작업 내용

마감이벤트 설정 등록 요청 DTO 예시는 다음과 같습니다.
`{
    "shopId": 3,
    "employeeId": 5,
    "message": "look at me look at me",
    "discountRate": 50,
    "menuIds": [3]
}`

해당 api 요청 시, 다음과 같은 경우 등록에 제한을 두도록 하였습니다.  

- 등록을 요청하는 메뉴(menuIds)가 직원(employeeId) 담당 메뉴가 아닌 경우
- 등록을 요청하는 직원(employeeId)이 가게(shopId)의 직원이 아닌 경우
- 해당 api 요청을 보내는 유저(토큰으로 식별)가 가게(shopId) 주인이 아닌 경우 