### PR TITLE
[feat] #227 일반회원 상세정보 조회 API 구현 

### DIFF
--- a/src/main/java/kyonggi/bookslyserver/domain/user/controller/UserController.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package kyonggi.bookslyserver.domain.user.controller;
 
+import kyonggi.bookslyserver.domain.user.dto.response.GetUserDetailInfoResponseDto;
 import kyonggi.bookslyserver.domain.user.dto.response.GetUserNicknameResponseDto;
 import kyonggi.bookslyserver.domain.user.dto.response.GetUserProfileResponseDto;
 import kyonggi.bookslyserver.domain.user.service.UserService;
@@ -11,7 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/user")
+@RequestMapping("/api/users")
 @RestController
 @Slf4j
 public class UserController {
@@ -22,6 +23,12 @@ public class UserController {
     @GetMapping("/test")
     public ResponseEntity<SuccessResponse<?>> test() {
         return SuccessResponse.ok("임시 리다이렉트 페이지");
+    }
+
+    @GetMapping("/details")
+    public ResponseEntity<SuccessResponse<?>> getUserDetailInfo(@UserId Long userId) {
+        GetUserDetailInfoResponseDto getUserDetailInfoResponseDto = userService.getDetailInfo(userId);
+        return SuccessResponse.ok(getUserDetailInfoResponseDto);
     }
 
     @GetMapping("/details/nickname")

--- a/src/main/java/kyonggi/bookslyserver/domain/user/dto/response/GetUserDetailInfoResponseDto.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/dto/response/GetUserDetailInfoResponseDto.java
@@ -1,0 +1,16 @@
+package kyonggi.bookslyserver.domain.user.dto.response;
+
+import kyonggi.bookslyserver.domain.user.entity.User;
+import lombok.Builder;
+
+@Builder
+public record GetUserDetailInfoResponseDto(
+        String phoneNumber,
+        String nickname
+) {
+    public static GetUserDetailInfoResponseDto of(User user) {
+        return GetUserDetailInfoResponseDto.builder()
+                .phoneNumber(user.getPhoneNum())
+                .nickname(user.getNickname()).build();
+    }
+}

--- a/src/main/java/kyonggi/bookslyserver/domain/user/service/UserService.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package kyonggi.bookslyserver.domain.user.service;
 
 import kyonggi.bookslyserver.domain.user.constant.Role;
+import kyonggi.bookslyserver.domain.user.dto.response.GetUserDetailInfoResponseDto;
 import kyonggi.bookslyserver.domain.user.dto.response.GetUserNicknameResponseDto;
 import kyonggi.bookslyserver.domain.user.dto.response.GetUserProfileResponseDto;
 import kyonggi.bookslyserver.domain.user.entity.User;
@@ -73,5 +74,11 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
         return GetUserProfileResponseDto.of(user);
+    }
+
+    public GetUserDetailInfoResponseDto getDetailInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+        return GetUserDetailInfoResponseDto.of(user);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- close : #227 
## 📝작업 내용

일반회원의 상세정보(전화번호와 닉네임)을 조회하는 기능을 구현하였습니다.
