### PR TITLE
Feature/#249 예약 도메인 API 수정

### DIFF
--- a/src/main/java/kyonggi/bookslyserver/domain/reservation/dto/ReserveRequestDTO.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/reservation/dto/ReserveRequestDTO.java
@@ -42,9 +42,9 @@ public class ReserveRequestDTO {
         private Integer discount;
         private String inquiry;
         /**
-         * 직원메뉴 아이디 리스트로 받아오기
+         * 직원메뉴 아이디 리스트
          */
-        private List<reservationMenuRequestDTO> reservationMenuRequestDTOS;
+        private List<reservationMenuRequestDTO> reservationMenus;
     }
     @Builder
     @Getter

--- a/src/main/java/kyonggi/bookslyserver/domain/reservation/dto/ReserveRequestDTO.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/reservation/dto/ReserveRequestDTO.java
@@ -27,7 +27,13 @@ public class ReserveRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class reservationMenuRequestDTO{
-        private Long empMenuId;
+        @NotNull
+        private boolean event;
+        private Integer discount;
+        @NotNull
+        private Long menuId;
+        @NotNull
+        private int price;
     }
     @Builder
     @Getter
@@ -35,15 +41,14 @@ public class ReserveRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class reservationRequestDTO{
-
+        @NotNull
         private Long reservationScheduleId;
-        private boolean event;
-        private String eventTitle;
-        private Integer discount;
+        private String timeEventTitle;
         private String inquiry;
         /**
-         * 직원메뉴 아이디 리스트
+         * 요청 메뉴 리스트
          */
+        @NotNull
         private List<reservationMenuRequestDTO> reservationMenus;
     }
     @Builder

--- a/src/main/java/kyonggi/bookslyserver/domain/reservation/dto/ReserveResponseDTO.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/reservation/dto/ReserveResponseDTO.java
@@ -195,6 +195,8 @@ public class ReserveResponseDTO {
         private boolean isConfirmed;
         private boolean isRefused;
         private boolean isCanceled;
+        private boolean isFavor;
+        private boolean hasReview;
     }
     @Builder
     @NoArgsConstructor

--- a/src/main/java/kyonggi/bookslyserver/domain/reservation/entity/Reservation.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/reservation/entity/Reservation.java
@@ -1,6 +1,7 @@
 package kyonggi.bookslyserver.domain.reservation.entity;
 
 import jakarta.persistence.*;
+import kyonggi.bookslyserver.domain.review.entity.Review;
 import kyonggi.bookslyserver.domain.user.entity.User;
 import kyonggi.bookslyserver.global.common.BaseTimeEntity;
 import lombok.*;
@@ -54,5 +55,9 @@ public class Reservation extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "reservation",cascade = CascadeType.ALL)
     private List<ReservationMenu> reservationMenus=new ArrayList<>();
+
+    @OneToOne
+    @JoinColumn(name="review_id")
+    private Review review;
 
 }

--- a/src/main/java/kyonggi/bookslyserver/domain/reservation/entity/Reservation.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/reservation/entity/Reservation.java
@@ -5,8 +5,6 @@ import kyonggi.bookslyserver.domain.user.entity.User;
 import kyonggi.bookslyserver.global.common.BaseTimeEntity;
 import lombok.*;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -41,7 +39,7 @@ public class Reservation extends BaseTimeEntity {
     private boolean isDeleted;
 
     @Column
-    private String eventTitle;
+    private String timeEventTitle;
 
     @Column
     private String refuseReason;

--- a/src/main/java/kyonggi/bookslyserver/domain/reservation/repository/CustomRepository/ReservationRepositoryCustomImpl.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/reservation/repository/CustomRepository/ReservationRepositoryCustomImpl.java
@@ -2,10 +2,12 @@ package kyonggi.bookslyserver.domain.reservation.repository.CustomRepository;
 
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import kyonggi.bookslyserver.domain.event.entity.closeEvent.QClosingEvent;
@@ -20,6 +22,7 @@ import kyonggi.bookslyserver.domain.shop.entity.Employee.QEmployee;
 import kyonggi.bookslyserver.domain.shop.entity.Menu.QMenu;
 import kyonggi.bookslyserver.domain.shop.entity.Menu.QMenuCategory;
 import kyonggi.bookslyserver.domain.shop.entity.Shop.QShop;
+import kyonggi.bookslyserver.domain.user.entity.QFavoriteShop;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -47,6 +50,7 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
     QTimeEvent timeEvent=QTimeEvent.timeEvent;
     QClosingEvent closingEvent=QClosingEvent.closingEvent;
     QMenuCategory menuCategory=QMenuCategory.menuCategory;
+    QFavoriteShop favoriteShop=QFavoriteShop.favoriteShop;
     /**
      * 예약 요청 조회
      */
@@ -395,6 +399,13 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
                                 shop.address.secondAddress,
                                 shop.address.thirdAddress
                         ).as("location"),
+                        ExpressionUtils.as(
+                                JPAExpressions.selectOne()
+                                        .from(favoriteShop)
+                                        .where(favoriteShop.user.id.eq(userId)
+                                                .and(favoriteShop.shop.id.eq(shop.id)))
+                                        .exists(),"isFavor"
+                        ),
                         employee.name.as("employeeName"))
                 )
                 .from(reservation)

--- a/src/main/java/kyonggi/bookslyserver/domain/reservation/repository/CustomRepository/ReservationRepositoryCustomImpl.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/reservation/repository/CustomRepository/ReservationRepositoryCustomImpl.java
@@ -18,6 +18,7 @@ import kyonggi.bookslyserver.domain.reservation.entity.QReservation;
 import kyonggi.bookslyserver.domain.reservation.entity.QReservationMenu;
 import kyonggi.bookslyserver.domain.reservation.entity.QReservationSchedule;
 import kyonggi.bookslyserver.domain.reservation.service.ReserveCommandService;
+import kyonggi.bookslyserver.domain.review.entity.QReview;
 import kyonggi.bookslyserver.domain.shop.entity.Employee.QEmployee;
 import kyonggi.bookslyserver.domain.shop.entity.Menu.QMenu;
 import kyonggi.bookslyserver.domain.shop.entity.Menu.QMenuCategory;
@@ -51,6 +52,7 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
     QClosingEvent closingEvent=QClosingEvent.closingEvent;
     QMenuCategory menuCategory=QMenuCategory.menuCategory;
     QFavoriteShop favoriteShop=QFavoriteShop.favoriteShop;
+    QReview review=QReview.review;
     /**
      * 예약 요청 조회
      */
@@ -406,8 +408,12 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
                                                 .and(favoriteShop.shop.id.eq(shop.id)))
                                         .exists(),"isFavor"
                         ),
-                        employee.name.as("employeeName"))
-                )
+                        employee.name.as("employeeName"),
+                        ExpressionUtils.as(JPAExpressions.selectOne()
+                                .from(review)
+                                .where(review.reservation.id.eq(reservation.id))
+                                .exists(),"hasReview")
+                ))
                 .from(reservation)
                 .join(reservation.reservationSchedule,reservationSchedule)
                 .join(reservationSchedule.shop,shop)

--- a/src/main/java/kyonggi/bookslyserver/domain/reservation/repository/CustomRepository/ReservationRepositoryCustomImpl.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/reservation/repository/CustomRepository/ReservationRepositoryCustomImpl.java
@@ -383,7 +383,7 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
         List<ReserveResponseDTO.myPageReservationsResultDTO> results=queryFactory.select(
                 Projections.fields(ReserveResponseDTO.myPageReservationsResultDTO.class,
                         reservation.id.as("reservationId"),
-                        reservation.eventTitle.as("eventTitle"),
+                        reservation.timeEventTitle.as("eventTitle"),
                         reservation.isRefused.as("isRefused"),
                         reservation.isCanceled.as("isCanceled"),
                         reservationSchedule.workDate.as("date"),

--- a/src/main/java/kyonggi/bookslyserver/domain/reservation/service/ReserveCommandService.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/reservation/service/ReserveCommandService.java
@@ -19,8 +19,6 @@ import kyonggi.bookslyserver.domain.shop.entity.Employee.Employee;
 import kyonggi.bookslyserver.domain.shop.entity.Employee.EmployeeMenu;
 import kyonggi.bookslyserver.domain.shop.repository.EmployeeMenuRepository;
 import kyonggi.bookslyserver.domain.shop.repository.EmployeeRepository;
-import kyonggi.bookslyserver.domain.shop.repository.ShopRepository;
-import kyonggi.bookslyserver.domain.user.entity.ShopOwner;
 import kyonggi.bookslyserver.domain.user.repository.UserRepository;
 import kyonggi.bookslyserver.global.error.ErrorCode;
 import kyonggi.bookslyserver.global.error.exception.EntityNotFoundException;
@@ -85,9 +83,9 @@ public class ReserveCommandService {
         /**
          *  가격 계산
          */
-        int totalPrice= requestDTO.getReservationMenuRequestDTOS().stream()
-                .mapToInt(menuDto->{
-                    EmployeeMenu employeeMenu=employeeMenuRepository.findById(menuDto.getEmpMenuId()).orElseThrow(()->new EntityNotFoundException(ErrorCode.EMPLOYEE_MENU_NOT_FOUND));
+        int totalPrice= requestDTO.getReservationMenus().stream()
+                .mapToInt(menu->{
+                    EmployeeMenu employeeMenu=employeeMenuRepository.findById(menu.getEmpMenuId()).orElseThrow(()->new EntityNotFoundException(ErrorCode.EMPLOYEE_MENU_NOT_FOUND));
                     return employeeMenu.getMenu().getPrice();
                 }).sum();
         if (requestDTO.isEvent()){
@@ -106,7 +104,7 @@ public class ReserveCommandService {
                 .price(totalPrice)
                 .reservationSchedule(reservationSchedule)
                 .inquiry(requestDTO.getInquiry())
-                .eventTitle(requestDTO.getEventTitle())
+                .timeEventTitle(requestDTO.getEventTitle())
                 .user(userRepository.findById(userId).orElseThrow(()->new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND)))
                 .reservationMenus(new ArrayList<>())
                 .isConfirmed(reservationSchedule.isAutoConfirmed())
@@ -116,7 +114,7 @@ public class ReserveCommandService {
         /**
          *  Reservation Menu 생성
          */
-        requestDTO.getReservationMenuRequestDTOS().forEach(menuDto -> {
+        requestDTO.getReservationMenus().forEach(menuDto -> {
             EmployeeMenu employeeMenu = employeeMenuRepository.findById(menuDto.getEmpMenuId())
                     .orElseThrow(() -> new EntityNotFoundException(ErrorCode.EMPLOYEE_MENU_NOT_FOUND));
             newReservation.getReservationMenus().add(

--- a/src/main/java/kyonggi/bookslyserver/domain/review/entity/Review.java
+++ b/src/main/java/kyonggi/bookslyserver/domain/review/entity/Review.java
@@ -1,6 +1,7 @@
 package kyonggi.bookslyserver.domain.review.entity;
 
 import jakarta.persistence.*;
+import kyonggi.bookslyserver.domain.reservation.entity.Reservation;
 import kyonggi.bookslyserver.domain.shop.entity.Employee.Employee;
 import kyonggi.bookslyserver.domain.shop.entity.Shop.Shop;
 import kyonggi.bookslyserver.domain.user.entity.User;
@@ -42,4 +43,7 @@ public class Review extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewImage> reviewImages = new ArrayList<>();
+
+    @OneToOne(mappedBy = "review",cascade = CascadeType.ALL)
+    private Reservation reservation;
 }

--- a/src/main/java/kyonggi/bookslyserver/global/error/ErrorCode.java
+++ b/src/main/java/kyonggi/bookslyserver/global/error/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode implements BaseErrorCode{
     EMPLOYEE_NOT_SETTING_CLOSING_EVENT(HttpStatus.BAD_REQUEST,"마감 이벤트 설정을 먼저 완료해주세요"),
     CURRENT_PASSWORD_IS_NULL(HttpStatus.BAD_REQUEST,"현재 비밀번호를 입력해주세요."),
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    MENUS_ARE_DUPLICATED(HttpStatus.BAD_REQUEST,"메뉴는 중복 선택할 수 없습니다"),
 
 
     /**


### PR DESCRIPTION
## #️⃣연관된 이슈

- close : #249 

## 📝작업 내용

> 사용자 예약하기 api의 검증 로직을 추가하고, 총 가격 계산과 예약 메뉴 생성 로직을 수정하였습니다. 

> 사용자 예약 내역 조회의 응답 dto에 대해 단골 가게 여부와 리뷰 존재 여부를 추가하였습니다.